### PR TITLE
Feat/#119 : planPreview 조회 api 구현

### DIFF
--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/plan/PlanController.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/plan/PlanController.java
@@ -17,7 +17,7 @@ public class PlanController {
     private final PlanService planService;
 
     @ApiOperation("미리보기 일정 정보를 조회합니다.")
-    @GetMapping("/v1/plan/preview/{planId}")
+    @GetMapping("/v2/plan/{planId}/preview")
     public PlanPreviewResponseDto getPlanPreview(@PathVariable Long planId) {
         return planService.getPlanPreview(planId);
     }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/plan/PlanController.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/plan/PlanController.java
@@ -20,5 +20,4 @@ public class PlanController {
     public void getPlanPreview(@PathVariable Long planId) {
         planService.getPlanPreview(planId);
     }
-
 }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/plan/PlanController.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/plan/PlanController.java
@@ -1,0 +1,24 @@
+package com.deploy.bemyplan.controller.plan;
+
+import com.deploy.bemyplan.service.plan.PlanService;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class PlanController {
+
+    private final PlanService planService;
+
+    @ApiOperation("미리보기 일정 정보를 조회합니다.")
+    @GetMapping("/v1/plan/preview/{planId}")
+    public void getPlanPreview(@PathVariable Long planId) {
+        planService.getPlanPreview(planId);
+    }
+
+}

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/plan/PlanController.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/plan/PlanController.java
@@ -1,6 +1,7 @@
 package com.deploy.bemyplan.controller.plan;
 
 import com.deploy.bemyplan.service.plan.PlanService;
+import com.deploy.bemyplan.service.plan.dto.response.PlanPreviewResponseDto;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,7 +18,7 @@ public class PlanController {
 
     @ApiOperation("미리보기 일정 정보를 조회합니다.")
     @GetMapping("/v1/plan/preview/{planId}")
-    public void getPlanPreview(@PathVariable Long planId) {
-        planService.getPlanPreview(planId);
+    public PlanPreviewResponseDto getPlanPreview(@PathVariable Long planId) {
+        return planService.getPlanPreview(planId);
     }
 }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/plan/PlanService.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/plan/PlanService.java
@@ -8,10 +8,12 @@ import com.deploy.bemyplan.domain.plan.PreviewRepository;
 import com.deploy.bemyplan.domain.plan.SpotCategoryType;
 import com.deploy.bemyplan.service.plan.dto.response.PlanPreviewResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.deploy.bemyplan.common.exception.ErrorCode.NOT_FOUND_PLAN_EXCEPTION;
 
@@ -29,8 +31,16 @@ public class PlanService {
 
         final int spotCount = getSpotCount(plan);
         final int restaurantCount = getRestaurantCount(plan);
+        final List<String> previewImages = getPreviewImages(previews);
 
-        return PlanPreviewResponseDto.of(plan, previews, spotCount, restaurantCount);
+        return PlanPreviewResponseDto.of(plan, previewImages, spotCount, restaurantCount);
+    }
+
+    @NotNull
+    private List<String> getPreviewImages(List<Preview> previews) {
+        return previews.stream()
+                .map(preview -> preview.getImageUrls().get(0))
+                .collect(Collectors.toList());
     }
 
     private int getRestaurantCount(final Plan plan) {

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/plan/PlanService.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/plan/PlanService.java
@@ -1,10 +1,24 @@
 package com.deploy.bemyplan.service.plan;
 
+import com.deploy.bemyplan.domain.plan.Plan;
+import com.deploy.bemyplan.domain.plan.PlanRepository;
+import com.deploy.bemyplan.domain.plan.Preview;
+import com.deploy.bemyplan.domain.plan.PreviewRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class PlanService {
-    public void getPlanPreview(Long planId) {
+    private final PlanRepository planRepository;
+    private final PreviewRepository previewRepository;
 
+    public void getPlanPreview(Long planId) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(Error::new); // 에러 처리
+
+        // 미리보기 db
+        Preview preview = previewRepository.findPreviewByPlanId(planId)
+                .orElseThrow(Error::new); //에러 처리
     }
 }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/plan/PlanService.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/plan/PlanService.java
@@ -1,11 +1,19 @@
 package com.deploy.bemyplan.service.plan;
 
+import com.deploy.bemyplan.common.exception.model.NotFoundException;
 import com.deploy.bemyplan.domain.plan.Plan;
 import com.deploy.bemyplan.domain.plan.PlanRepository;
 import com.deploy.bemyplan.domain.plan.Preview;
 import com.deploy.bemyplan.domain.plan.PreviewRepository;
+import com.deploy.bemyplan.domain.plan.SpotCategoryType;
+import com.deploy.bemyplan.service.plan.dto.response.PlanPreviewResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.deploy.bemyplan.common.exception.ErrorCode.NOT_FOUND_PLAN_EXCEPTION;
 
 @Service
 @RequiredArgsConstructor
@@ -13,12 +21,28 @@ public class PlanService {
     private final PlanRepository planRepository;
     private final PreviewRepository previewRepository;
 
-    public void getPlanPreview(Long planId) {
+    @Transactional(readOnly = true)
+    public PlanPreviewResponseDto getPlanPreview(Long planId) {
         Plan plan = planRepository.findById(planId)
-                .orElseThrow(Error::new); // 에러 처리
+                .orElseThrow(() -> new NotFoundException(String.format("존재하지 않는 일정 (%s) 입니다", planId), NOT_FOUND_PLAN_EXCEPTION));
+        List<Preview> previews = previewRepository.findAllPreviewByPlanId(planId);
 
-        // 미리보기 db
-        Preview preview = previewRepository.findPreviewByPlanId(planId)
-                .orElseThrow(Error::new); //에러 처리
+        final int spotCount = getSpotCount(plan);
+        final int restaurantCount = getRestaurantCount(plan);
+
+        return PlanPreviewResponseDto.of(plan, previews, spotCount, restaurantCount);
+    }
+
+    private int getRestaurantCount(final Plan plan) {
+        return (int) plan.getSchedules().stream()
+                .flatMap(dailySchedule -> dailySchedule.getSpots().stream())
+                .filter(spot -> SpotCategoryType.RESTAURANT == spot.getCategory())
+                .count();
+    }
+
+    private int getSpotCount(final Plan plan) {
+        return (int) plan.getSchedules().stream()
+                .mapToLong(dailySchedule -> (long) dailySchedule.getSpots().size())
+                .sum();
     }
 }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/plan/PlanService.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/plan/PlanService.java
@@ -1,0 +1,10 @@
+package com.deploy.bemyplan.service.plan;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class PlanService {
+    public void getPlanPreview(Long planId) {
+
+    }
+}

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/plan/dto/response/PlanPreviewResponseDto.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/plan/dto/response/PlanPreviewResponseDto.java
@@ -1,0 +1,62 @@
+package com.deploy.bemyplan.service.plan.dto.response;
+
+import com.deploy.bemyplan.common.dto.AuditingTimeResponse;
+import com.deploy.bemyplan.domain.common.Money;
+import com.deploy.bemyplan.domain.plan.Plan;
+import com.deploy.bemyplan.domain.plan.Preview;
+import com.deploy.bemyplan.domain.plan.TravelMobility;
+import com.deploy.bemyplan.domain.plan.TravelPartner;
+import com.deploy.bemyplan.domain.plan.TravelTheme;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PlanPreviewResponseDto extends AuditingTimeResponse {
+
+    private Long planId;
+    private String title;
+    private String description;
+    private List<String> thumbnail;
+    private List<String> hashtag;
+    private TravelTheme theme;
+    private int spotCount;
+    private int restaurantCount;
+    private int totalDay;
+    private TravelPartner travelPartner;
+    private Money budget;
+    private TravelMobility travelMobility;
+    private int month;
+    private int price;
+    private List<String> recommendTarget;
+
+    public static PlanPreviewResponseDto of(@NotNull final Plan plan, @NotNull final List<Preview> previews,int spotCount,int restaurantCount) {
+        return new PlanPreviewResponseDto(
+                plan.getId(),
+                plan.getTitle(),
+                plan.getDescription(),
+                previews.stream().filter(preview -> preview.getSpotId() == 1)
+                        .map(preview -> preview.getImageUrls().get(0)).collect(Collectors.toList()), //각 장소당 하나
+                plan.getHashtags(),
+                plan.getTagInfo().getTheme(),
+                spotCount,
+                restaurantCount,
+                plan.getTagInfo().getTotalDay(),
+                plan.getTagInfo().getPartner(),
+                plan.getTagInfo().getBudget(),
+                plan.getTagInfo().getMobility(),
+                plan.getTagInfo().getMonth(),
+                plan.getPrice(),
+                plan.getRecommendTargets()
+        );
+    }
+}

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/plan/dto/response/PlanPreviewResponseDto.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/plan/dto/response/PlanPreviewResponseDto.java
@@ -3,7 +3,6 @@ package com.deploy.bemyplan.service.plan.dto.response;
 import com.deploy.bemyplan.common.dto.AuditingTimeResponse;
 import com.deploy.bemyplan.domain.common.Money;
 import com.deploy.bemyplan.domain.plan.Plan;
-import com.deploy.bemyplan.domain.plan.Preview;
 import com.deploy.bemyplan.domain.plan.TravelMobility;
 import com.deploy.bemyplan.domain.plan.TravelPartner;
 import com.deploy.bemyplan.domain.plan.TravelTheme;
@@ -15,7 +14,6 @@ import lombok.ToString;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @ToString
@@ -39,13 +37,12 @@ public class PlanPreviewResponseDto extends AuditingTimeResponse {
     private int price;
     private List<String> recommendTarget;
 
-    public static PlanPreviewResponseDto of(@NotNull final Plan plan, @NotNull final List<Preview> previews,int spotCount,int restaurantCount) {
-        return new PlanPreviewResponseDto(
+    public static PlanPreviewResponseDto of(@NotNull final Plan plan, final List<String> previewImages, final int spotCount, final int restaurantCount) {
+        final PlanPreviewResponseDto response = new PlanPreviewResponseDto(
                 plan.getId(),
                 plan.getTitle(),
                 plan.getDescription(),
-                previews.stream().filter(preview -> preview.getSpotId() == 1)
-                        .map(preview -> preview.getImageUrls().get(0)).collect(Collectors.toList()), //각 장소당 하나
+                previewImages,
                 plan.getHashtags(),
                 plan.getTagInfo().getTheme(),
                 spotCount,
@@ -58,5 +55,7 @@ public class PlanPreviewResponseDto extends AuditingTimeResponse {
                 plan.getPrice(),
                 plan.getRecommendTargets()
         );
+        response.setBaseTime(plan.getCreatedAt(), plan.getUpdatedAt());
+        return response;
     }
 }

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/plan/PlanControllerTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/plan/PlanControllerTest.java
@@ -1,6 +1,12 @@
 package com.deploy.bemyplan.controller.plan;
 
+import com.deploy.bemyplan.domain.plan.Plan;
+import com.deploy.bemyplan.domain.plan.PlanStatus;
+import com.deploy.bemyplan.domain.plan.RcmndStatus;
+import com.deploy.bemyplan.domain.plan.RegionType;
+import com.deploy.bemyplan.domain.plan.TagInfo;
 import com.deploy.bemyplan.service.plan.PlanService;
+import com.deploy.bemyplan.service.plan.dto.response.PlanPreviewResponseDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -8,13 +14,19 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.List;
+
+import static com.deploy.bemyplan.domain.plan.Plan.newInstance;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class PlanControllerTest {
-
     private MockMvc mockMvc;
 
     @Mock
@@ -39,5 +51,30 @@ class PlanControllerTest {
         mockMvc.perform(get("/api/v1/plan/preview/1"));
 
         verify(stubPlanService, times(1)).getPlanPreview(1L);
+    }
+
+    @Test
+    void getPlanPreviewReturnsResponse() throws Exception {
+        Plan givenPlan = newInstance(1L, RegionType.JEJU, "thumbnail", "title", "description", TagInfo.testBuilder().build(), 2000, PlanStatus.ACTIVE, RcmndStatus.NONE);
+        PlanPreviewResponseDto response = PlanPreviewResponseDto.of(givenPlan, List.of("image.png", "image2.png"), 21, 1);
+        given(stubPlanService.getPlanPreview(any())).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/plan/preview/{planId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.planId", equalTo(response.getPlanId())))
+                .andExpect(jsonPath("$.title", equalTo(response.getTitle())))
+                .andExpect(jsonPath("$.description", equalTo(response.getDescription())))
+                .andExpect(jsonPath("$.price", equalTo(response.getPrice())))
+                .andExpect(jsonPath("$.month", equalTo(response.getMonth())))
+                .andExpect(jsonPath("$.totalDay", equalTo(response.getTotalDay())))
+                .andExpect(jsonPath("$.theme", equalTo(response.getTheme())))
+                .andExpect(jsonPath("$.budget", equalTo(response.getBudget())))
+                .andExpect(jsonPath("$.hashtag", equalTo(response.getHashtag())))
+                .andExpect(jsonPath("$.recommendTarget", equalTo(response.getRecommendTarget())))
+                .andExpect(jsonPath("$.travelMobility", equalTo(response.getTravelMobility())))
+                .andExpect(jsonPath("$.restaurantCount", equalTo(response.getRestaurantCount())))
+                .andExpect(jsonPath("$.spotCount", equalTo(response.getSpotCount())))
+                .andExpect(jsonPath("$.thumbnail", equalTo(response.getThumbnail())))
+                .andExpect(jsonPath("$.budget", equalTo(response.getTravelPartner())));
     }
 }

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/plan/PlanControllerTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/plan/PlanControllerTest.java
@@ -75,6 +75,6 @@ class PlanControllerTest {
                 .andExpect(jsonPath("$.restaurantCount", equalTo(response.getRestaurantCount())))
                 .andExpect(jsonPath("$.spotCount", equalTo(response.getSpotCount())))
                 .andExpect(jsonPath("$.thumbnail", equalTo(response.getThumbnail())))
-                .andExpect(jsonPath("$.budget", equalTo(response.getTravelPartner())));
+                .andExpect(jsonPath("$.travelPartner", equalTo(response.getTravelPartner())));
     }
 }

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/plan/PlanControllerTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/plan/PlanControllerTest.java
@@ -1,0 +1,43 @@
+package com.deploy.bemyplan.controller.plan;
+
+import com.deploy.bemyplan.service.plan.PlanService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class PlanControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private PlanService stubPlanService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(new PlanController(stubPlanService))
+                .build();
+    }
+
+    @Test
+    void getPlanPreviewReturnsOkHttpStatus() throws Exception {
+        mockMvc.perform(get("/api/v1/plan/preview/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void getPlanPreviewPassesPlanIdToService() throws Exception {
+        mockMvc.perform(get("/api/v1/plan/preview/1"));
+
+        verify(stubPlanService, times(1)).getPlanPreview(1L);
+    }
+}

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/service/plan/PlanServiceTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/service/plan/PlanServiceTest.java
@@ -1,0 +1,61 @@
+package com.deploy.bemyplan.service.plan;
+
+import com.deploy.bemyplan.domain.plan.Plan;
+import com.deploy.bemyplan.domain.plan.PlanRepository;
+import com.deploy.bemyplan.domain.plan.PlanStatus;
+import com.deploy.bemyplan.domain.plan.Preview;
+import com.deploy.bemyplan.domain.plan.PreviewContentStatus;
+import com.deploy.bemyplan.domain.plan.PreviewRepository;
+import com.deploy.bemyplan.domain.plan.RcmndStatus;
+import com.deploy.bemyplan.domain.plan.RegionType;
+import com.deploy.bemyplan.domain.plan.TagInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.deploy.bemyplan.domain.plan.Plan.newInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class PlanServiceTest {
+    private PlanService planService;
+    private PlanRepository stubPlanRepository;
+    private PreviewRepository stubPreviewRepository;
+
+
+    @BeforeEach
+    void setUp() {
+        stubPlanRepository = mock(PlanRepository.class);
+        stubPreviewRepository = mock(PreviewRepository.class);
+
+        planService = new PlanService(stubPlanRepository, stubPreviewRepository);
+    }
+
+//    @Test
+//    void getPlanPreview_passesPlanFromRepository() {
+//        Plan givenPlan = newInstance(1L, RegionType.JEJU, "thumbnailUrl", "title", "description", TagInfo.testBuilder().build(), 10000, PlanStatus.ACTIVE, RcmndStatus.NONE);
+//        given(stubPlanRepository.findById(any())).willReturn(Optional.of(givenPlan));
+//
+//        planService.getPlanPreview(1L);
+//
+//        verify(stubPlanRepository, times(1)).findById(1L);
+//    }
+
+    @Test
+    void getPlanPreview_passesPreviewFromRepository() {
+        Plan givenPlan = newInstance(1L, RegionType.JEJU, "thumbnailUrl", "title", "description", TagInfo.testBuilder().build(), 10000, PlanStatus.ACTIVE, RcmndStatus.NONE);
+        Preview givenPreview = Preview.newInstance(givenPlan, "image.png", "description", PreviewContentStatus.ACTIVE);
+        given(stubPlanRepository.findById(any())).willReturn(Optional.of(givenPlan));
+        given(stubPreviewRepository.findPreviewByPlanId(givenPlan.getId())).willReturn(Optional.of(givenPreview));
+
+        planService.getPlanPreview(1L);
+
+        verify(stubPreviewRepository, times(1)).findPreviewByPlanId(1L);
+    }
+
+
+}

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/service/plan/PlanServiceTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/service/plan/PlanServiceTest.java
@@ -1,5 +1,6 @@
 package com.deploy.bemyplan.service.plan;
 
+import com.deploy.bemyplan.common.exception.model.NotFoundException;
 import com.deploy.bemyplan.domain.plan.Plan;
 import com.deploy.bemyplan.domain.plan.PlanRepository;
 import com.deploy.bemyplan.domain.plan.PlanStatus;
@@ -9,12 +10,16 @@ import com.deploy.bemyplan.domain.plan.PreviewRepository;
 import com.deploy.bemyplan.domain.plan.RcmndStatus;
 import com.deploy.bemyplan.domain.plan.RegionType;
 import com.deploy.bemyplan.domain.plan.TagInfo;
+import com.deploy.bemyplan.service.plan.dto.response.PlanPreviewResponseDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.deploy.bemyplan.domain.plan.Plan.newInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -23,39 +28,73 @@ import static org.mockito.Mockito.verify;
 
 class PlanServiceTest {
     private PlanService planService;
-    private PlanRepository stubPlanRepository;
-    private PreviewRepository stubPreviewRepository;
+    private PlanRepository spyPlanRepository;
+    private PreviewRepository spyPreviewRepository;
 
 
     @BeforeEach
     void setUp() {
-        stubPlanRepository = mock(PlanRepository.class);
-        stubPreviewRepository = mock(PreviewRepository.class);
+        spyPlanRepository = mock(PlanRepository.class);
+        spyPreviewRepository = mock(PreviewRepository.class);
 
-        planService = new PlanService(stubPlanRepository, stubPreviewRepository);
+        planService = new PlanService(spyPlanRepository, spyPreviewRepository);
     }
-
-//    @Test
-//    void getPlanPreview_passesPlanFromRepository() {
-//        Plan givenPlan = newInstance(1L, RegionType.JEJU, "thumbnailUrl", "title", "description", TagInfo.testBuilder().build(), 10000, PlanStatus.ACTIVE, RcmndStatus.NONE);
-//        given(stubPlanRepository.findById(any())).willReturn(Optional.of(givenPlan));
-//
-//        planService.getPlanPreview(1L);
-//
-//        verify(stubPlanRepository, times(1)).findById(1L);
-//    }
 
     @Test
-    void getPlanPreview_passesPreviewFromRepository() {
+    void getPlanPreview_callsPlanFromRepository() {
         Plan givenPlan = newInstance(1L, RegionType.JEJU, "thumbnailUrl", "title", "description", TagInfo.testBuilder().build(), 10000, PlanStatus.ACTIVE, RcmndStatus.NONE);
-        Preview givenPreview = Preview.newInstance(givenPlan, "image.png", "description", PreviewContentStatus.ACTIVE);
-        given(stubPlanRepository.findById(any())).willReturn(Optional.of(givenPlan));
-        given(stubPreviewRepository.findPreviewByPlanId(givenPlan.getId())).willReturn(Optional.of(givenPreview));
+        Preview givenPreview = Preview.newInstance(givenPlan, List.of("img1.png"), "", PreviewContentStatus.ACTIVE, 1L);
+        given(spyPlanRepository.findById(any())).willReturn(Optional.of(givenPlan));
+        given(spyPreviewRepository.findAllPreviewByPlanId(givenPlan.getId())).willReturn(List.of(givenPreview));
 
-        planService.getPlanPreview(1L);
+        planService.getPlanPreview(givenPlan.getId());
 
-        verify(stubPreviewRepository, times(1)).findPreviewByPlanId(1L);
+        verify(spyPlanRepository, times(1)).findById(givenPlan.getId());
     }
 
+    @Test
+    void getPlanPreview_callsPreviewFromRepository() {
+        Plan givenPlan = newInstance(1L, RegionType.JEJU, "", "", "", TagInfo.testBuilder().build(), 0, PlanStatus.ACTIVE, RcmndStatus.NONE);
+        Preview givenPreview = Preview.newInstance(givenPlan, List.of("image.png"), "description", PreviewContentStatus.ACTIVE, 1L);
+        given(spyPlanRepository.findById(any())).willReturn(Optional.of(givenPlan));
+        given(spyPreviewRepository.findAllPreviewByPlanId(givenPlan.getId())).willReturn(List.of(givenPreview));
 
+        planService.getPlanPreview(givenPlan.getId());
+
+        verify(spyPreviewRepository, times(1)).findAllPreviewByPlanId(givenPlan.getId());
+    }
+
+    @Test
+    void getPlanPreview_returnsPlanPreview() {
+        Plan givenPlan = newInstance(1L, RegionType.JEJU, "", "", "", TagInfo.testBuilder().build(), 0, PlanStatus.ACTIVE, RcmndStatus.NONE);
+        Preview givenPreview1 = Preview.newInstance(givenPlan, List.of("image.png", "image2.png"), "description", PreviewContentStatus.ACTIVE, 1L);
+        Preview givenPreview2 = Preview.newInstance(givenPlan, List.of("2ndImage.png", "image2.png"), "description", PreviewContentStatus.ACTIVE, 1L);
+        given(spyPlanRepository.findById(any())).willReturn(Optional.of(givenPlan));
+        given(spyPreviewRepository.findAllPreviewByPlanId(givenPlan.getId())).willReturn(List.of(givenPreview1, givenPreview2));
+
+        PlanPreviewResponseDto result = planService.getPlanPreview(givenPlan.getId());
+
+        assertThat(result.getPlanId()).isEqualTo(givenPlan.getId());
+        assertThat(result.getTitle()).isEqualTo(givenPlan.getTitle());
+        assertThat(result.getDescription()).isEqualTo(givenPlan.getDescription());
+        assertThat(result.getThumbnail()).isEqualTo(List.of(givenPreview1.getImageUrls().get(0), givenPreview2.getImageUrls().get(0)));
+        assertThat(result.getHashtag()).isEqualTo(givenPlan.getHashtags());
+        assertThat(result.getTheme()).isEqualTo(givenPlan.getTagInfo().getTheme());
+        assertThat(result.getSpotCount()).isEqualTo(0);
+        assertThat(result.getRestaurantCount()).isEqualTo(0);
+        assertThat(result.getTotalDay()).isEqualTo(givenPlan.getTagInfo().getTotalDay());
+        assertThat(result.getTravelPartner()).isEqualTo(givenPlan.getTagInfo().getPartner());
+        assertThat(result.getBudget()).isEqualTo(givenPlan.getTagInfo().getBudget());
+        assertThat(result.getTravelMobility()).isEqualTo(givenPlan.getTagInfo().getMobility());
+        assertThat(result.getMonth()).isEqualTo(givenPlan.getTagInfo().getMonth());
+        assertThat(result.getPrice()).isEqualTo(givenPlan.getPrice());
+        assertThat(result.getRecommendTarget()).isEqualTo(givenPlan.getRecommendTargets());
+    }
+
+    @Test
+    void getPlanPreview_returnsNotFoundExceptionWhenPlanNotExists(){
+
+        assertThatThrownBy(() -> planService.getPlanPreview(1L))
+                .isInstanceOf(NotFoundException.class);
+    }
 }

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/common/ListToStringConverter.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/common/ListToStringConverter.java
@@ -1,0 +1,24 @@
+package com.deploy.bemyplan.domain.common;
+
+import javax.persistence.AttributeConverter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class ListToStringConverter implements AttributeConverter<List<String>, String> {
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        return attribute == null ? null : String.join(",", attribute);
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        return isNullOrEmpty(dbData)
+                ? Collections.emptyList() : new ArrayList<>(Arrays.asList(dbData.split(",")));
+    }
+
+    private boolean isNullOrEmpty(String dbData) {
+        return dbData == null || "".equals(dbData);
+    }
+}

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Plan.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Plan.java
@@ -67,11 +67,11 @@ public class Plan extends AuditingTimeEntity {
 
     @Column(length = 100)
     @Convert(converter = ListToStringConverter.class)
-    private List<String> hashtags;
+    private List<String> hashtags = new ArrayList<>();
 
     @Column(length = 200)
     @Convert(converter = ListToStringConverter.class)
-    private List<String> recommendTargets;
+    private List<String> recommendTargets = new ArrayList<>();
 
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<DailySchedule> schedules = new ArrayList<>();

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Plan.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Plan.java
@@ -83,7 +83,11 @@ public class Plan extends AuditingTimeEntity {
         this.rcmndStatus = rcmndStatus;
     }
 
-    public void updateOrderCnt(){
+    public static Plan newInstance(Long userId, RegionType region, String thumbnailUrl, String title, String description, TagInfo tagInfo, int price, PlanStatus status, RcmndStatus rcmndStatus) {
+        return new Plan(userId, region, thumbnailUrl, title, description, tagInfo, 0, 0, price, status, rcmndStatus);
+    }
+
+    public void updateOrderCnt() {
         this.orderCnt += 1;
     }
 }

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Plan.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Plan.java
@@ -1,12 +1,14 @@
 package com.deploy.bemyplan.domain.plan;
 
 import com.deploy.bemyplan.domain.common.AuditingTimeEntity;
+import com.deploy.bemyplan.domain.common.ListToStringConverter;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -63,11 +65,35 @@ public class Plan extends AuditingTimeEntity {
     @Enumerated(EnumType.STRING)
     private RcmndStatus rcmndStatus;
 
+    @Column(length = 100)
+    @Convert(converter = ListToStringConverter.class)
+    private List<String> hashtags;
+
+    @Column(length = 200)
+    @Convert(converter = ListToStringConverter.class)
+    private List<String> recommendTargets;
+
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<DailySchedule> schedules = new ArrayList<>();
 
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<PreviewContent> previews = new ArrayList<>();
+
+    private Plan(final Long userId, final RegionType region, final String thumbnailUrl, final String title, final String description, final TagInfo tagInfo, final int orderCnt, final int viewCnt, final int price, final PlanStatus status, final RcmndStatus rcmndStatus, final List<String> hashtags, final List<String> recommendTargets) {
+        this.userId = userId;
+        this.region = region;
+        this.thumbnailUrl = thumbnailUrl;
+        this.title = title;
+        this.description = description;
+        this.tagInfo = tagInfo;
+        this.orderCnt = orderCnt;
+        this.viewCnt = viewCnt;
+        this.price = price;
+        this.status = status;
+        this.rcmndStatus = rcmndStatus;
+        this.hashtags = hashtags;
+        this.recommendTargets = recommendTargets;
+    }
 
     private Plan(Long userId, RegionType region, String thumbnailUrl, String title, String description, TagInfo tagInfo, int orderCnt, int viewCnt, int price, PlanStatus status, RcmndStatus rcmndStatus) {
         this.userId = userId;
@@ -85,6 +111,10 @@ public class Plan extends AuditingTimeEntity {
 
     public static Plan newInstance(Long userId, RegionType region, String thumbnailUrl, String title, String description, TagInfo tagInfo, int price, PlanStatus status, RcmndStatus rcmndStatus) {
         return new Plan(userId, region, thumbnailUrl, title, description, tagInfo, 0, 0, price, status, rcmndStatus);
+    }
+
+    public static Plan newInstance(Long userId, RegionType region, String thumbnailUrl, String title, String description, TagInfo tagInfo, int price, PlanStatus status, RcmndStatus rcmndStatus, List<String> hashtags, List<String> recommendTargets) {
+        return new Plan(userId, region, thumbnailUrl, title, description, tagInfo, 0, 0, price, status, rcmndStatus, hashtags, recommendTargets);
     }
 
     public void updateOrderCnt() {

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/PlanRepository.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/PlanRepository.java
@@ -3,5 +3,8 @@ package com.deploy.bemyplan.domain.plan;
 import com.deploy.bemyplan.domain.plan.repository.PlanRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PlanRepository extends JpaRepository<Plan, Long>, PlanRepositoryCustom {
+    Optional<Plan> findById(Long id);
 }

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/PlanRepository.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/PlanRepository.java
@@ -3,8 +3,5 @@ package com.deploy.bemyplan.domain.plan;
 import com.deploy.bemyplan.domain.plan.repository.PlanRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface PlanRepository extends JpaRepository<Plan, Long>, PlanRepositoryCustom {
-    Optional<Plan> findById(Long id);
 }

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Preview.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Preview.java
@@ -36,4 +36,15 @@ public class Preview {
     @Column(nullable = false, length = 30)
     @Enumerated(EnumType.STRING)
     private PreviewContentStatus status;
+
+    private Preview(final Plan plan, final String imageUrl, final String description, final PreviewContentStatus status) {
+        this.plan = plan;
+        this.imageUrl = imageUrl;
+        this.description = description;
+        this.status = status;
+    }
+
+    public static Preview newInstance(final Plan plan, final String imageUrl, final String description, final PreviewContentStatus status) {
+        return new Preview(plan, imageUrl, description, status);
+    }
 }

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Preview.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Preview.java
@@ -1,0 +1,39 @@
+package com.deploy.bemyplan.domain.plan;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Preview {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Column(length = 1000)
+    private String imageUrl;
+
+    @Column(length = 2000)
+    private String description;
+
+    @Column(nullable = false, length = 30)
+    @Enumerated(EnumType.STRING)
+    private PreviewContentStatus status;
+}

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Preview.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Preview.java
@@ -16,6 +16,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -32,7 +33,7 @@ public class Preview {
 
     @Column(length = 1000)
     @Convert(converter = ListToStringConverter.class)
-    private List<String> imageUrls;
+    private List<String> imageUrls = new ArrayList<>();
 
     @Column(length = 2000)
     private String description;

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Preview.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Preview.java
@@ -1,10 +1,12 @@
 package com.deploy.bemyplan.domain.plan;
 
+import com.deploy.bemyplan.domain.common.ListToStringConverter;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -14,6 +16,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import java.util.List;
 
 @Entity
 @Getter
@@ -28,7 +31,8 @@ public class Preview {
     private Plan plan;
 
     @Column(length = 1000)
-    private String imageUrl;
+    @Convert(converter = ListToStringConverter.class)
+    private List<String> imageUrls;
 
     @Column(length = 2000)
     private String description;
@@ -37,14 +41,18 @@ public class Preview {
     @Enumerated(EnumType.STRING)
     private PreviewContentStatus status;
 
-    private Preview(final Plan plan, final String imageUrl, final String description, final PreviewContentStatus status) {
+    @Column(nullable = false)
+    private Long spotId;
+
+    private Preview(final Plan plan, final List<String> imageUrls, final String description, final PreviewContentStatus status, final Long spotId) {
         this.plan = plan;
-        this.imageUrl = imageUrl;
+        this.imageUrls = imageUrls;
         this.description = description;
         this.status = status;
+        this.spotId = spotId;
     }
 
-    public static Preview newInstance(final Plan plan, final String imageUrl, final String description, final PreviewContentStatus status) {
-        return new Preview(plan, imageUrl, description, status);
+    public static Preview newInstance(final Plan plan, final List<String> imageUrls, final String description, final PreviewContentStatus status, final Long spotId) {
+        return new Preview(plan, imageUrls, description, status, spotId);
     }
 }

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/PreviewRepository.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/PreviewRepository.java
@@ -1,0 +1,9 @@
+package com.deploy.bemyplan.domain.plan;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PreviewRepository extends JpaRepository<Preview, Long> {
+    Optional<Preview> findPreviewByPlanId(Long planId);
+}

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/PreviewRepository.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/PreviewRepository.java
@@ -2,8 +2,8 @@ package com.deploy.bemyplan.domain.plan;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface PreviewRepository extends JpaRepository<Preview, Long> {
-    Optional<Preview> findPreviewByPlanId(Long planId);
+    List<Preview> findAllPreviewByPlanId(Long planId);
 }


### PR DESCRIPTION
- plan 미리보기 조회 api 구현했습니다.

- plan entity 컬럼(해시태그, 추천대상 컬럼 추가)
- preview 엔티티 추가

뭐 등등등...