### PR TITLE
Feat/#135 : 결제 확정 api 구현

### DIFF
--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/payment/PaymentController.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/payment/PaymentController.java
@@ -1,6 +1,7 @@
 package com.deploy.bemyplan.controller.payment;
 
 import com.deploy.bemyplan.common.dto.ApiResponse;
+import com.deploy.bemyplan.controller.payment.dto.request.ConfirmOrderRequest;
 import com.deploy.bemyplan.controller.payment.dto.request.UserPurchaseReceipt;
 import com.deploy.bemyplan.service.payment.PaymentService;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,14 @@ public class PaymentController {
     private final PaymentService paymentService;
 
     @PostMapping("/{orderId}/verify")
-    public ApiResponse validatePurchase(@PathVariable Long orderId, @RequestBody UserPurchaseReceipt userReceipt){
+    public ApiResponse validatePurchase(@PathVariable Long orderId, @RequestBody UserPurchaseReceipt userReceipt) {
         return ApiResponse.success(paymentService.purchaseValidate(orderId, userReceipt.toServiceDto()));
+    }
+
+    @PostMapping("/{orderId}/confirm")
+    public final ApiResponse confirmPurchase(@PathVariable final Long orderId, @RequestBody final ConfirmOrderRequest request) {
+        paymentService.purchaseConfirm(orderId, request.toServiceDto(request.getPaymentId(), request.getUserId()));
+
+        return ApiResponse.SUCCESS;
     }
 }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/payment/dto/request/ConfirmOrderRequest.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/payment/dto/request/ConfirmOrderRequest.java
@@ -1,0 +1,21 @@
+package com.deploy.bemyplan.controller.payment.dto.request;
+
+import com.deploy.bemyplan.service.payment.dto.request.ConfirmOrderDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public final class ConfirmOrderRequest {
+    private Long paymentId;
+    private Long userId;
+
+    public ConfirmOrderDto toServiceDto(Long paymentId, Long userId) {
+        return ConfirmOrderDto.of(paymentId, userId);
+    }
+}

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/OrderService.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/OrderService.java
@@ -25,13 +25,13 @@ public class OrderService {
     public void createOrder(final Long planId, final Long userId) {
         final Plan plan = planRepository.findPlanById(planId);
         plan.updateOrderCnt();
-        orderRepository.save(Order.of(planId, userId, OrderStatus.PASSIVE, plan.getPrice()));
+        orderRepository.save(Order.of(planId, userId, OrderStatus.UNPAID, plan.getPrice()));
     }
 
     @Transactional(readOnly = true)
     public void checkOrderStatus(final Long planId, final Long userId) {
         final Optional<Order> maybeOrder = orderRepository.findByPlanIdAndUserId(planId, userId);
-        if (maybeOrder.isPresent()) {
+        if (maybeOrder.isPresent() && OrderStatus.COMPLETED == maybeOrder.get().getStatus()) {
             throw new NotFoundException("이미 구매한 일정입니다.", CONFLICT_ORDER_PLAN);
         }
     }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/payment/PaymentService.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/payment/PaymentService.java
@@ -1,8 +1,11 @@
 package com.deploy.bemyplan.service.payment;
 
+import com.deploy.bemyplan.service.payment.dto.request.ConfirmOrderDto;
 import com.deploy.bemyplan.service.payment.dto.request.UserReceiptDto;
 import com.deploy.bemyplan.service.payment.dto.response.InAppPurchaseResponse;
 
 public interface PaymentService {
     InAppPurchaseResponse purchaseValidate(Long orderId, UserReceiptDto userReceiptDto);
+
+    void purchaseConfirm(Long orderId, ConfirmOrderDto confirmOrderDto);
 }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/payment/dto/request/ConfirmOrderDto.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/payment/dto/request/ConfirmOrderDto.java
@@ -1,0 +1,20 @@
+package com.deploy.bemyplan.service.payment.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+@Getter
+public class ConfirmOrderDto {
+    private Long paymentId;
+    private Long userId;
+
+    public static ConfirmOrderDto of(Long paymentId, Long userId) {
+        return new ConfirmOrderDto(paymentId, userId);
+    }
+}

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/payment/dto/response/InAppPurchaseResponse.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/payment/dto/response/InAppPurchaseResponse.java
@@ -7,10 +7,12 @@ import lombok.ToString;
 @Getter
 @ToString
 public class InAppPurchaseResponse {
+    private final Long id;
     private final PaymentState status;
     private final String transactionId;
 
-    private InAppPurchaseResponse(final PaymentState status, final String transactionId) {
+    private InAppPurchaseResponse(final Long id, final PaymentState status, final String transactionId) {
+        this.id = id;
         this.status = status;
         this.transactionId = transactionId;
     }
@@ -19,8 +21,9 @@ public class InAppPurchaseResponse {
         return PaymentState.COMPLETE == status;
     }
 
-    public static InAppPurchaseResponse of(final PaymentState status, final String transactionId){
+    public static InAppPurchaseResponse of(final Long id, final PaymentState status, final String transactionId) {
         InAppPurchaseResponse response = new InAppPurchaseResponse(
+                id,
                 status,
                 transactionId
         );

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/payment/impl/ApplePaymentService.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/payment/impl/ApplePaymentService.java
@@ -1,6 +1,8 @@
 package com.deploy.bemyplan.service.payment.impl;
 
 import com.deploy.bemyplan.common.exception.model.NotFoundException;
+import com.deploy.bemyplan.common.exception.model.ValidationException;
+import com.deploy.bemyplan.service.payment.dto.request.ConfirmOrderDto;
 import com.deploy.bemyplan.domain.order.Order;
 import com.deploy.bemyplan.domain.order.OrderRepository;
 import com.deploy.bemyplan.domain.payment.Payment;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 import static com.deploy.bemyplan.common.exception.ErrorCode.NOT_FOUND_EXCEPTION;
 
@@ -41,7 +44,23 @@ public class ApplePaymentService implements PaymentService {
         final Payment payment = findOrCreatePayment(order, transactionId, PaymentState.fromCode(response.getStatus()));
         paymentRepository.save(payment);
 
-        return InAppPurchaseResponse.of(payment.getPaymentState(), payment.getTransactionId());
+        return InAppPurchaseResponse.of(payment.getId(), payment.getPaymentState(), payment.getTransactionId());
+    }
+
+    @Transactional
+    @Override
+    public void purchaseConfirm(final Long orderId, final ConfirmOrderDto confirmOrderDto) {
+        final Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 주문 내역 입니다.", NOT_FOUND_EXCEPTION));
+
+        final Payment payment = paymentRepository.findById(confirmOrderDto.getPaymentId())
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 결제 내역 입니다.", NOT_FOUND_EXCEPTION));
+
+        if (!Objects.equals(orderId, payment.getOrder().getId()))
+            throw new ValidationException("결제된 주문이 요청된 주문과 일치하지 않습니다.");
+        if (PaymentState.COMPLETE != payment.getPaymentState()) throw new ValidationException("결제 처리가 정상적으로 되지 않았습니다.");
+
+        order.orderComplete(payment);
     }
 
     private Payment findOrCreatePayment(final Order order, final String transactionId, final PaymentState paymentState) {

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/payment/impl/ApplePaymentService.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/payment/impl/ApplePaymentService.java
@@ -2,7 +2,6 @@ package com.deploy.bemyplan.service.payment.impl;
 
 import com.deploy.bemyplan.common.exception.model.NotFoundException;
 import com.deploy.bemyplan.common.exception.model.ValidationException;
-import com.deploy.bemyplan.service.payment.dto.request.ConfirmOrderDto;
 import com.deploy.bemyplan.domain.order.Order;
 import com.deploy.bemyplan.domain.order.OrderRepository;
 import com.deploy.bemyplan.domain.payment.Payment;
@@ -11,6 +10,7 @@ import com.deploy.bemyplan.domain.payment.PaymentState;
 import com.deploy.bemyplan.external.client.apple.purchase.dto.response.AppStoreResponse;
 import com.deploy.bemyplan.external.client.apple.purchase.dto.response.InApp;
 import com.deploy.bemyplan.service.payment.PaymentService;
+import com.deploy.bemyplan.service.payment.dto.request.ConfirmOrderDto;
 import com.deploy.bemyplan.service.payment.dto.request.UserReceiptDto;
 import com.deploy.bemyplan.service.payment.dto.response.InAppPurchaseResponse;
 import com.deploy.bemyplan.service.payment.utils.AppleInAppPurchaseValidator;
@@ -56,9 +56,8 @@ public class ApplePaymentService implements PaymentService {
         final Payment payment = paymentRepository.findById(confirmOrderDto.getPaymentId())
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 결제 내역 입니다.", NOT_FOUND_EXCEPTION));
 
-        if (!Objects.equals(orderId, payment.getOrder().getId()))
-            throw new ValidationException("결제된 주문이 요청된 주문과 일치하지 않습니다.");
-        if (PaymentState.COMPLETE != payment.getPaymentState()) throw new ValidationException("결제 처리가 정상적으로 되지 않았습니다.");
+        if (!Objects.equals(orderId, payment.getOrder().getId()) || PaymentState.COMPLETE != payment.getPaymentState())
+            throw new ValidationException("결제 처리가 정상적으로 되지 않았습니다.");
 
         order.orderComplete(payment);
     }

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/payment/PaymentControllerTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/payment/PaymentControllerTest.java
@@ -1,0 +1,48 @@
+package com.deploy.bemyplan.controller.payment;
+
+import com.deploy.bemyplan.service.payment.PaymentService;
+import com.deploy.bemyplan.service.payment.dto.request.ConfirmOrderDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class PaymentControllerTest {
+    private MockMvc mockMvc;
+
+    @Mock
+    private PaymentService stubPaymentService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(new PaymentController(stubPaymentService))
+                .build();
+    }
+
+    @Test
+    void confirmPurchaseReturnsHttpOkStatus() throws Exception {
+        mockMvc.perform(post("/api/v1/payment/1/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"paymentId\":1,\"userId\":1}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void confirmPurchasePassesDtoToService() throws Exception {
+        mockMvc.perform(post("/api/v1/payment/1/confirm")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"paymentId\":1,\"userId\":1}"));
+
+        verify(stubPaymentService, times(1)).purchaseConfirm(1L, ConfirmOrderDto.of(1L, 1L));
+    }
+}

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/service/payment/impl/ApplePaymentServiceTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/service/payment/impl/ApplePaymentServiceTest.java
@@ -1,0 +1,101 @@
+package com.deploy.bemyplan.service.payment.impl;
+
+import com.deploy.bemyplan.common.exception.model.ValidationException;
+import com.deploy.bemyplan.domain.order.Order;
+import com.deploy.bemyplan.domain.order.OrderRepository;
+import com.deploy.bemyplan.domain.order.OrderStatus;
+import com.deploy.bemyplan.domain.payment.Payment;
+import com.deploy.bemyplan.domain.payment.PaymentRepository;
+import com.deploy.bemyplan.domain.payment.PaymentState;
+import com.deploy.bemyplan.service.payment.dto.request.ConfirmOrderDto;
+import com.deploy.bemyplan.service.payment.utils.AppleInAppPurchaseValidator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class ApplePaymentServiceTest {
+    private ApplePaymentService paymentService;
+    private AppleInAppPurchaseValidator spyAppleInAppPurchaseValidator;
+    private OrderRepository spyOrderRepository;
+    private PaymentRepository spyPaymentRepository;
+
+    @BeforeEach
+    void setUp() {
+        spyAppleInAppPurchaseValidator = mock(AppleInAppPurchaseValidator.class);
+        spyOrderRepository = mock(OrderRepository.class);
+        spyPaymentRepository = mock(PaymentRepository.class);
+
+        paymentService = new ApplePaymentService(spyAppleInAppPurchaseValidator, spyOrderRepository, spyPaymentRepository);
+    }
+
+    @Test
+    void purchaseConfirm_callsOrderFromRepository() {
+        Order givenOrder = Order.of(1L, 1L, OrderStatus.COMPLETED, 1000);
+        Payment givenPayment = Payment.of(givenOrder, "1111", PaymentState.COMPLETE);
+        given(spyOrderRepository.findById(givenOrder.getId())).willReturn(Optional.of(givenOrder));
+        given(spyPaymentRepository.findById(any())).willReturn(Optional.of(givenPayment));
+
+        paymentService.purchaseConfirm(givenOrder.getId(), ConfirmOrderDto.of(1L, 1L));
+
+        verify(spyOrderRepository, times(1)).findById(givenOrder.getId());
+    }
+
+    @Test
+    void purchaseConfirm_callsPaymentFromRepository() {
+        final Order givenOrder = Order.of(1L, 1L, OrderStatus.COMPLETED, 1000);
+        final Payment givenPayment = Payment.of(givenOrder, "1111", PaymentState.COMPLETE);
+        given(spyOrderRepository.findById(any())).willReturn(Optional.of(givenOrder));
+        given(spyPaymentRepository.findById(givenPayment.getId())).willReturn(Optional.of(givenPayment));
+
+        paymentService.purchaseConfirm(givenOrder.getId(), ConfirmOrderDto.of(givenPayment.getId(), 1L));
+
+        verify(spyPaymentRepository, times(1)).findById(givenPayment.getId());
+    }
+
+    @Test
+    void purchaseConfirm_changesStatus() {
+        final Order givenOrder = Order.of(1L, 1L, OrderStatus.UNPAID, 1000);
+        final Payment givenPayment = Payment.of(givenOrder, "1111", PaymentState.COMPLETE);
+        given(spyOrderRepository.findById(givenOrder.getId())).willReturn(Optional.of(givenOrder));
+        given(spyPaymentRepository.findById(givenPayment.getId())).willReturn(Optional.of(givenPayment));
+
+        paymentService.purchaseConfirm(givenOrder.getId(), ConfirmOrderDto.of(givenPayment.getId(), 1L));
+
+        Assertions.assertThat(givenOrder.getStatus()).isEqualTo(OrderStatus.COMPLETED);
+    }
+
+    @Test
+    void purchaseConfirm_returnsValidationExceptionWhenOrderIdIsNotEqual() {
+        final Order givenOrder = Order.of(1L, 1L, OrderStatus.UNPAID, 1000);
+        final Order anotherOrder = Order.of(2L, 1L, OrderStatus.UNPAID, 2000);
+        final Payment givenPayment = Payment.of(anotherOrder, "1111", PaymentState.COMPLETE);
+
+        given(spyOrderRepository.findById(any())).willReturn(Optional.of(givenOrder));
+        given(spyPaymentRepository.findById(givenPayment.getId())).willReturn(Optional.of(givenPayment));
+
+        assertThatThrownBy(() -> paymentService.purchaseConfirm(1L, ConfirmOrderDto.of(givenPayment.getId(), 1L)))
+                .isInstanceOf(ValidationException.class);
+    }
+
+    @Test
+    void purchaseConfirm_returnsValidationExceptionWhenPaymentIsNotCompleted() {
+        final Order givenOrder = Order.of(1L, 1L, OrderStatus.UNPAID, 1000);
+        final Payment givenPayment = Payment.of(givenOrder, "1111", PaymentState.FAIL);
+
+        given(spyOrderRepository.findById(any())).willReturn(Optional.of(givenOrder));
+        given(spyPaymentRepository.findById(givenPayment.getId())).willReturn(Optional.of(givenPayment));
+
+        assertThatThrownBy(() -> paymentService.purchaseConfirm(givenOrder.getId(), ConfirmOrderDto.of(givenPayment.getId(), 1L)))
+                .isInstanceOf(ValidationException.class);
+
+    }
+}

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/order/Order.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/order/Order.java
@@ -56,7 +56,8 @@ public class Order extends AuditingTimeEntity {
         return new Order(planId, userId, status, price);
     }
 
-    public void orderComplete(){
-        this.status = OrderStatus.ACTIVE;
+    public void orderComplete(Payment payment) {
+        this.payments.add(payment);
+        this.status = OrderStatus.COMPLETED;
     }
 }

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/order/Order.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/order/Order.java
@@ -1,6 +1,7 @@
 package com.deploy.bemyplan.domain.order;
 
 import com.deploy.bemyplan.domain.common.AuditingTimeEntity;
+import com.deploy.bemyplan.domain.payment.Payment;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,8 +13,11 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -37,6 +41,9 @@ public class Order extends AuditingTimeEntity {
 
     @Column
     private int orderPrice;
+
+    @OneToMany(mappedBy = "order")
+    private List<Payment> payments = new ArrayList<>();
 
     private Order(Long planId, Long userId, OrderStatus status, int price) {
         this.planId = planId;

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/order/OrderStatus.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/order/OrderStatus.java
@@ -1,7 +1,9 @@
 package com.deploy.bemyplan.domain.order;
 
 public enum OrderStatus {
-    ACTIVE,
-    PASSIVE
+    FAILED,
+    UNPAID,
+    COMPLETED,
+    CANCELED,
     ;
 }


### PR DESCRIPTION
- 영수증 검증 이후, 결제 확정 api 입니다.

- payment 상태가 올바른지, payment의 주문과 order의 주문이 같은지 확인 후, order의 상태를 COMPLETED로 변경합니다.
- order - payment의 상태를 양방향 1:n 관계로 수정하여 order에서도 payment의 상태를 갖게 했습니다. 

- 수고링