### PR TITLE
Feature/#156 구매 내역 조회 api 추가

### DIFF
--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/order/OrderController.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/order/OrderController.java
@@ -28,7 +28,7 @@ public class OrderController {
     @Auth
     @PostMapping("/v1/plan/order")
     public OrderResponseDto createOrder(@Valid @RequestBody final CreateOrderRequest request, @UserId final Long userId) {
-        return orderService.createOrder(request.getPlanId(), userId);
+        return orderService.createOrder(request.getPlanId(),request.getOrderPrice(), userId);
     }
 
     @ApiOperation("[인증] 여행일정 조회/상세 페이지 - 해당 여행일정 구매 여부를 확인합니다. (성공 시 구매하지 않은 상태)")

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/order/OrderController.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/order/OrderController.java
@@ -5,6 +5,7 @@ import com.deploy.bemyplan.config.resolver.UserId;
 import com.deploy.bemyplan.controller.common.response.ResponseDTO;
 import com.deploy.bemyplan.service.order.OrderService;
 import com.deploy.bemyplan.service.order.dto.request.CreateOrderRequest;
+import com.deploy.bemyplan.service.order.dto.response.OrderListResponse;
 import com.deploy.bemyplan.service.order.dto.response.OrderResponseDto;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -28,14 +29,22 @@ public class OrderController {
     @Auth
     @PostMapping("/v1/plan/order")
     public OrderResponseDto createOrder(@Valid @RequestBody final CreateOrderRequest request, @UserId final Long userId) {
-        return orderService.createOrder(request.getPlanId(),request.getOrderPrice(), userId);
+        return orderService.createOrder(request.getPlanId(), request.getOrderPrice(), userId);
     }
 
     @ApiOperation("[인증] 여행일정 조회/상세 페이지 - 해당 여행일정 구매 여부를 확인합니다. (성공 시 구매하지 않은 상태)")
     @Auth
     @GetMapping("/v1/plan/order/{planId}")
-    public ResponseDTO checkOrderStatus(@PathVariable final Long planId, @UserId final Long userId){
+    public ResponseDTO checkOrderStatus(@PathVariable final Long planId, @UserId final Long userId) {
         orderService.checkOrderStatus(planId, userId);
         return ResponseDTO.of("해당 여행일정을 구매할 수 있습니다.");
+    }
+
+    @ApiOperation("[인증] 내가 구매한 여행 일정 내역을 조회합니다.")
+    @Auth
+    @GetMapping("/v1/order/plans")
+    public OrderListResponse getMyOrderedPlanList(@UserId final Long userId) {
+        return null;
+        //        return orderService.getMyOrderList(userId);
     }
 }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/order/OrderController.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/order/OrderController.java
@@ -44,7 +44,6 @@ public class OrderController {
     @Auth
     @GetMapping("/v1/order/plans")
     public OrderListResponse getMyOrderedPlanList(@UserId final Long userId) {
-        return null;
-        //        return orderService.getMyOrderList(userId);
+        return orderService.getOrderedPlanList(userId);
     }
 }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/plan/PlanRetrieveController.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/controller/plan/PlanRetrieveController.java
@@ -71,7 +71,7 @@ public class PlanRetrieveController {
     @Auth
     @GetMapping("/v1/plan/bookmark")
     public ScrapsScrollResponse retrieveMyBookmarkList(@UserId final Long userId, @Valid final RetrieveMyBookmarkListRequestDto request,
-                                                                    @AllowedSortProperties({"id", "createdAt", "orderCnt"}) final Pageable pageable) {
+                                                       @AllowedSortProperties({"id", "createdAt", "orderCnt"}) final Pageable pageable) {
         return planRetrieveService.retrieveMyBookmarkList(request, userId, pageable);
     }
 
@@ -79,7 +79,7 @@ public class PlanRetrieveController {
     @Auth
     @GetMapping("/v1/plan/orders")
     public OrdersScrollResponse retrieveMyOrderList(@UserId final Long userId, @Valid final RetrieveMyOrderListRequestDto request,
-                                                                 @AllowedSortProperties({"id", "createdAt", "orderCnt"}) final Pageable pageable) {
+                                                    @AllowedSortProperties({"id", "createdAt", "orderCnt"}) final Pageable pageable) {
         return planRetrieveService.retrieveMyOrderList(request, userId, pageable);
     }
 }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/OrderService.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/OrderService.java
@@ -24,13 +24,13 @@ public class OrderService {
     private final PlanRepository planRepository;
 
     @Transactional
-    public OrderResponseDto createOrder(final Long planId, final Long userId) {
+    public OrderResponseDto createOrder(final Long planId, final int orderPrice, final Long userId) {
         final Plan plan = planRepository.findById(planId)
                 .orElseThrow(() -> new NotFoundException("해당하는 일정이 없습니다.", NOT_FOUND_EXCEPTION));
         final Order order = orderRepository.findByPlanIdAndUserId(planId, userId)
                 .orElseGet(() -> {
                     plan.updateOrderCnt();
-                    return Order.of(planId, userId, OrderStatus.UNPAID, plan.getPrice());
+                    return Order.of(planId, userId, OrderStatus.UNPAID, orderPrice);
                 });
 
         orderRepository.save(order);

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/OrderService.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/OrderService.java
@@ -4,14 +4,19 @@ import com.deploy.bemyplan.common.exception.model.NotFoundException;
 import com.deploy.bemyplan.domain.order.Order;
 import com.deploy.bemyplan.domain.order.OrderRepository;
 import com.deploy.bemyplan.domain.order.OrderStatus;
+import com.deploy.bemyplan.domain.plan.OrderedPlan;
 import com.deploy.bemyplan.domain.plan.Plan;
 import com.deploy.bemyplan.domain.plan.PlanRepository;
+import com.deploy.bemyplan.service.order.dto.response.OrderListResponse;
 import com.deploy.bemyplan.service.order.dto.response.OrderResponseDto;
+import com.deploy.bemyplan.service.order.dto.response.OrderedPlanInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.deploy.bemyplan.common.exception.ErrorCode.CONFLICT_ORDER_PLAN;
 import static com.deploy.bemyplan.common.exception.ErrorCode.NOT_FOUND_EXCEPTION;
@@ -44,5 +49,15 @@ public class OrderService {
         if (maybeOrder.isPresent() && OrderStatus.COMPLETED == maybeOrder.get().getStatus()) {
             throw new NotFoundException("이미 구매한 일정입니다.", CONFLICT_ORDER_PLAN);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public OrderListResponse getOrderedPlanList(final Long userId) {
+        final List<OrderedPlan> orderedPlanList = planRepository.findAllByOrderAndUserId(userId);
+
+        return OrderListResponse.of(orderedPlanList
+                .stream()
+                .map(OrderedPlanInfoResponse::of)
+                .collect(Collectors.toList()));
     }
 }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/dto/request/CreateOrderRequest.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/dto/request/CreateOrderRequest.java
@@ -1,6 +1,10 @@
 package com.deploy.bemyplan.service.order.dto.request;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import javax.validation.constraints.NotNull;
 
@@ -12,4 +16,7 @@ public class CreateOrderRequest {
 
     @NotNull(message = "{plan.id.notNull}")
     private Long planId;
+
+    @NotNull
+    private int orderPrice;
 }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/dto/response/OrderListResponse.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/dto/response/OrderListResponse.java
@@ -1,0 +1,4 @@
+package com.deploy.bemyplan.service.order.dto.response;
+
+public class OrderListResponse {
+}

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/dto/response/OrderListResponse.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/dto/response/OrderListResponse.java
@@ -1,4 +1,24 @@
 package com.deploy.bemyplan.service.order.dto.response;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class OrderListResponse {
+    List<OrderedPlanInfoResponse> contents = new ArrayList<>();
+
+    private OrderListResponse(final List<OrderedPlanInfoResponse> contents) {
+        this.contents.addAll(contents);
+    }
+
+    public static OrderListResponse of(final List<OrderedPlanInfoResponse> contents) {
+        return new OrderListResponse(contents);
+    }
 }

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/dto/response/OrderedPlanInfoResponse.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/dto/response/OrderedPlanInfoResponse.java
@@ -3,11 +3,9 @@ package com.deploy.bemyplan.service.order.dto.response;
 import com.deploy.bemyplan.common.dto.AuditingTimeResponse;
 import com.deploy.bemyplan.domain.plan.OrderedPlan;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.jetbrains.annotations.NotNull;
 
 @ToString
 @Getter
@@ -18,7 +16,6 @@ public class OrderedPlanInfoResponse extends AuditingTimeResponse {
     private String title;
     private int orderPrice;
 
-    @Builder(access = AccessLevel.PRIVATE)
     private OrderedPlanInfoResponse(final Long planId, final String thumbnailUrl, final String title, final int orderPrice) {
         this.planId = planId;
         this.thumbnailUrl = thumbnailUrl;
@@ -26,7 +23,7 @@ public class OrderedPlanInfoResponse extends AuditingTimeResponse {
         this.orderPrice = orderPrice;
     }
 
-    public static OrderedPlanInfoResponse of(@NotNull OrderedPlan orderedPlan) {
+    public static OrderedPlanInfoResponse of(OrderedPlan orderedPlan) {
         OrderedPlanInfoResponse response = new OrderedPlanInfoResponse(
                 orderedPlan.getId(),
                 orderedPlan.getThumbnailUrl(),

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/dto/response/OrderedPlanInfoResponse.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/dto/response/OrderedPlanInfoResponse.java
@@ -1,0 +1,40 @@
+package com.deploy.bemyplan.service.order.dto.response;
+
+import com.deploy.bemyplan.common.dto.AuditingTimeResponse;
+import com.deploy.bemyplan.domain.plan.OrderedPlan;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.jetbrains.annotations.NotNull;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderedPlanInfoResponse extends AuditingTimeResponse {
+    private Long planId;
+    private String thumbnailUrl;
+    private String title;
+    private int orderPrice;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private OrderedPlanInfoResponse(Long planId, String thumbnailUrl, String title, int orderPrice) {
+        this.planId = planId;
+        this.thumbnailUrl = thumbnailUrl;
+        this.title = title;
+        this.orderPrice = orderPrice;
+    }
+
+    public static OrderedPlanInfoResponse of(@NotNull OrderedPlan orderedPlan) {
+        OrderedPlanInfoResponse response = new OrderedPlanInfoResponse(
+                orderedPlan.getId(),
+                orderedPlan.getThumbnailUrl(),
+                orderedPlan.getTitle(),
+                orderedPlan.getOrderPrice()
+        );
+
+        response.setBaseTime(orderedPlan.getCreatedAt(), orderedPlan.getUpdatedAt());
+        return response;
+    }
+}

--- a/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/dto/response/OrderedPlanInfoResponse.java
+++ b/application-bemyplan/src/main/java/com/deploy/bemyplan/service/order/dto/response/OrderedPlanInfoResponse.java
@@ -19,7 +19,7 @@ public class OrderedPlanInfoResponse extends AuditingTimeResponse {
     private int orderPrice;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private OrderedPlanInfoResponse(Long planId, String thumbnailUrl, String title, int orderPrice) {
+    private OrderedPlanInfoResponse(final Long planId, final String thumbnailUrl, final String title, final int orderPrice) {
         this.planId = planId;
         this.thumbnailUrl = thumbnailUrl;
         this.title = title;

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/order/OrderControllerTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/order/OrderControllerTest.java
@@ -1,14 +1,6 @@
 package com.deploy.bemyplan.controller.order;
 
-import com.deploy.bemyplan.domain.plan.OrderedPlan;
-import com.deploy.bemyplan.domain.plan.PlanStatus;
-import com.deploy.bemyplan.domain.plan.RcmndStatus;
-import com.deploy.bemyplan.domain.plan.Region;
-import com.deploy.bemyplan.domain.plan.RegionCategory;
-import com.deploy.bemyplan.domain.plan.TagInfo;
 import com.deploy.bemyplan.service.order.OrderService;
-import com.deploy.bemyplan.service.order.dto.response.OrderListResponse;
-import com.deploy.bemyplan.service.order.dto.response.OrderedPlanInfoResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -16,15 +8,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.util.Collections;
-import java.util.List;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class OrderControllerTest {
@@ -45,19 +29,5 @@ class OrderControllerTest {
     void getOrderedPlanListReturnsOKHttpStatus() throws Exception {
         mockMvc.perform(get("/api/v1/order/plans"))
                 .andExpect(status().isOk());
-    }
-
-    @Test
-    void getOrderPlanListReturnsResponse() throws Exception {
-        OrderedPlan givenPlan = OrderedPlan.newInstance(1L, RegionCategory.JEJU, Region.JEJUALL, "thumbnailUrl", "title", "description", TagInfo.testBuilder().build(), 10000, 100, 4000, PlanStatus.ACTIVE, RcmndStatus.NONE, Collections.emptyList(), Collections.emptyList(), 4400);
-        OrderListResponse response = OrderListResponse.of(List.of(OrderedPlanInfoResponse.of(givenPlan)));
-        given(stubOrderService.getOrderedPlanList(any())).willReturn(response);
-
-        mockMvc.perform(get("/api/v1/order/plans"))
-                .andDo(print())
-                .andExpect(jsonPath("$.contents[0].planId", equalTo(response.getContents().get(0).getPlanId())))
-                .andExpect(jsonPath("$.contents[0].orderPrice", equalTo(response.getContents().get(0).getOrderPrice())))
-                .andExpect(jsonPath("$.contents[0].title", equalTo(response.getContents().get(0).getTitle())))
-                .andExpect(jsonPath("$.contents[0].thumbnailUrl", equalTo(response.getContents().get(0).getThumbnailUrl())));
     }
 }

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/order/OrderControllerTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/order/OrderControllerTest.java
@@ -1,0 +1,33 @@
+package com.deploy.bemyplan.controller.order;
+
+import com.deploy.bemyplan.service.order.OrderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class OrderControllerTest {
+    private MockMvc mockMvc;
+
+    @Mock
+    private OrderService stubOrderService;
+
+    @BeforeEach
+    void setUp(){
+        MockitoAnnotations.openMocks(this);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(new OrderController(stubOrderService))
+                .build();
+    }
+
+    @Test
+    void getOrderedPlanListReturnsOKHttpStatus() throws Exception{
+        mockMvc.perform(get("/api/v1/order/plans"))
+                .andExpect(status().isOk());
+    }
+}

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/order/OrderControllerTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/controller/order/OrderControllerTest.java
@@ -1,6 +1,14 @@
 package com.deploy.bemyplan.controller.order;
 
+import com.deploy.bemyplan.domain.plan.OrderedPlan;
+import com.deploy.bemyplan.domain.plan.PlanStatus;
+import com.deploy.bemyplan.domain.plan.RcmndStatus;
+import com.deploy.bemyplan.domain.plan.Region;
+import com.deploy.bemyplan.domain.plan.RegionCategory;
+import com.deploy.bemyplan.domain.plan.TagInfo;
 import com.deploy.bemyplan.service.order.OrderService;
+import com.deploy.bemyplan.service.order.dto.response.OrderListResponse;
+import com.deploy.bemyplan.service.order.dto.response.OrderedPlanInfoResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -8,7 +16,15 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class OrderControllerTest {
@@ -18,7 +34,7 @@ class OrderControllerTest {
     private OrderService stubOrderService;
 
     @BeforeEach
-    void setUp(){
+    void setUp() {
         MockitoAnnotations.openMocks(this);
 
         mockMvc = MockMvcBuilders.standaloneSetup(new OrderController(stubOrderService))
@@ -26,8 +42,22 @@ class OrderControllerTest {
     }
 
     @Test
-    void getOrderedPlanListReturnsOKHttpStatus() throws Exception{
+    void getOrderedPlanListReturnsOKHttpStatus() throws Exception {
         mockMvc.perform(get("/api/v1/order/plans"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void getOrderPlanListReturnsResponse() throws Exception {
+        OrderedPlan givenPlan = OrderedPlan.newInstance(1L, RegionCategory.JEJU, Region.JEJUALL, "thumbnailUrl", "title", "description", TagInfo.testBuilder().build(), 10000, 100, 4000, PlanStatus.ACTIVE, RcmndStatus.NONE, Collections.emptyList(), Collections.emptyList(), 4400);
+        OrderListResponse response = OrderListResponse.of(List.of(OrderedPlanInfoResponse.of(givenPlan)));
+        given(stubOrderService.getOrderedPlanList(any())).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/order/plans"))
+                .andDo(print())
+                .andExpect(jsonPath("$.contents[0].planId", equalTo(response.getContents().get(0).getPlanId())))
+                .andExpect(jsonPath("$.contents[0].orderPrice", equalTo(response.getContents().get(0).getOrderPrice())))
+                .andExpect(jsonPath("$.contents[0].title", equalTo(response.getContents().get(0).getTitle())))
+                .andExpect(jsonPath("$.contents[0].thumbnailUrl", equalTo(response.getContents().get(0).getThumbnailUrl())));
     }
 }

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/service/order/OrderServiceTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/service/order/OrderServiceTest.java
@@ -3,6 +3,7 @@ package com.deploy.bemyplan.service.order;
 import com.deploy.bemyplan.domain.order.Order;
 import com.deploy.bemyplan.domain.order.OrderRepository;
 import com.deploy.bemyplan.domain.order.OrderStatus;
+import com.deploy.bemyplan.domain.plan.OrderedPlan;
 import com.deploy.bemyplan.domain.plan.Plan;
 import com.deploy.bemyplan.domain.plan.PlanRepository;
 import com.deploy.bemyplan.domain.plan.PlanStatus;
@@ -10,17 +11,21 @@ import com.deploy.bemyplan.domain.plan.RcmndStatus;
 import com.deploy.bemyplan.domain.plan.Region;
 import com.deploy.bemyplan.domain.plan.RegionCategory;
 import com.deploy.bemyplan.domain.plan.TagInfo;
+import com.deploy.bemyplan.service.order.dto.response.OrderListResponse;
 import com.deploy.bemyplan.service.order.dto.response.OrderResponseDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 class OrderServiceTest {
     private OrderService orderService;
@@ -69,5 +74,26 @@ class OrderServiceTest {
         orderService.createOrder(givenPlan.getId(), 1000, 1L);
 
         Assertions.assertThat(givenPlan.getOrderCnt()).isEqualTo(previousOrderCount + 1);
+    }
+
+    @Test
+    void getOrderedPlanListCallsPlanRepository() {
+        orderService.getOrderedPlanList(1L);
+
+        verify(spyPlanRepository, times(1)).findAllByOrderAndUserId(1L);
+    }
+
+    @Test
+    void getOrderedPlanListReturnsOrderListResponse() {
+        OrderedPlan givenPlan = OrderedPlan.newInstance(1L, RegionCategory.JEJU, Region.JEJUALL, "thumbnailUrl", "title", "description", TagInfo.testBuilder().build(), 10000, 100, 4000, PlanStatus.ACTIVE, RcmndStatus.NONE, Collections.emptyList(), Collections.emptyList(), 4400);
+
+        given(spyPlanRepository.findAllByOrderAndUserId(any())).willReturn((List<OrderedPlan>) List.of(givenPlan));
+
+        OrderListResponse result = orderService.getOrderedPlanList(1L);
+
+        Assertions.assertThat(result.getContents().get(0).getOrderPrice()).isEqualTo(givenPlan.getOrderPrice());
+        Assertions.assertThat(result.getContents().get(0).getPlanId()).isEqualTo(givenPlan.getId());
+        Assertions.assertThat(result.getContents().get(0).getThumbnailUrl()).isEqualTo(givenPlan.getThumbnailUrl());
+        Assertions.assertThat(result.getContents().get(0).getTitle()).isEqualTo(givenPlan.getTitle());
     }
 }

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/service/order/OrderServiceTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/service/order/OrderServiceTest.java
@@ -41,7 +41,7 @@ class OrderServiceTest {
         given(spyPlanRepository.findById(any())).willReturn(Optional.of(givenPlan));
         given(spyOrderRepository.findByPlanIdAndUserId(givenPlan.getId(), 1L)).willReturn(Optional.of(existedOrder));
 
-        OrderResponseDto result = orderService.createOrder(givenPlan.getId(), 1L);
+        OrderResponseDto result = orderService.createOrder(givenPlan.getId(), 1000, 1L);
 
         Assertions.assertThat(result.getOrderId()).isEqualTo(existedOrder.getId());
     }
@@ -54,7 +54,7 @@ class OrderServiceTest {
         given(spyPlanRepository.findById(any())).willReturn(Optional.of(givenPlan));
         given(spyOrderRepository.findByPlanIdAndUserId(givenPlan.getId(), 1L)).willReturn(Optional.of(existedOrder));
 
-        orderService.createOrder(givenPlan.getId(), 1L);
+        orderService.createOrder(givenPlan.getId(), 1000, 1L);
 
         Assertions.assertThat(givenPlan.getOrderCnt()).isEqualTo(previousOrderCount);
     }
@@ -66,7 +66,7 @@ class OrderServiceTest {
         int previousOrderCount = givenPlan.getOrderCnt();
         given(spyPlanRepository.findById(any())).willReturn(Optional.of(givenPlan));
 
-        orderService.createOrder(givenPlan.getId(), 1L);
+        orderService.createOrder(givenPlan.getId(), 1000, 1L);
 
         Assertions.assertThat(givenPlan.getOrderCnt()).isEqualTo(previousOrderCount + 1);
     }

--- a/application-bemyplan/src/test/java/com/deploy/bemyplan/service/order/OrderServiceTest.java
+++ b/application-bemyplan/src/test/java/com/deploy/bemyplan/service/order/OrderServiceTest.java
@@ -3,7 +3,6 @@ package com.deploy.bemyplan.service.order;
 import com.deploy.bemyplan.domain.order.Order;
 import com.deploy.bemyplan.domain.order.OrderRepository;
 import com.deploy.bemyplan.domain.order.OrderStatus;
-import com.deploy.bemyplan.domain.plan.OrderedPlan;
 import com.deploy.bemyplan.domain.plan.Plan;
 import com.deploy.bemyplan.domain.plan.PlanRepository;
 import com.deploy.bemyplan.domain.plan.PlanStatus;
@@ -11,14 +10,12 @@ import com.deploy.bemyplan.domain.plan.RcmndStatus;
 import com.deploy.bemyplan.domain.plan.Region;
 import com.deploy.bemyplan.domain.plan.RegionCategory;
 import com.deploy.bemyplan.domain.plan.TagInfo;
-import com.deploy.bemyplan.service.order.dto.response.OrderListResponse;
 import com.deploy.bemyplan.service.order.dto.response.OrderResponseDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -64,7 +61,6 @@ class OrderServiceTest {
         Assertions.assertThat(givenPlan.getOrderCnt()).isEqualTo(previousOrderCount);
     }
 
-
     @Test
     void createOrderUpdatesOrderCntWhenNoExistOrder() {
         Plan givenPlan = Plan.newInstance(1L, RegionCategory.JEJU, Region.JEJUALL, "thumbnailUrl", "title", "description", TagInfo.testBuilder().build(), 10000, PlanStatus.ACTIVE, RcmndStatus.NONE, Collections.emptyList(), Collections.emptyList());
@@ -81,19 +77,5 @@ class OrderServiceTest {
         orderService.getOrderedPlanList(1L);
 
         verify(spyPlanRepository, times(1)).findAllByOrderAndUserId(1L);
-    }
-
-    @Test
-    void getOrderedPlanListReturnsOrderListResponse() {
-        OrderedPlan givenPlan = OrderedPlan.newInstance(1L, RegionCategory.JEJU, Region.JEJUALL, "thumbnailUrl", "title", "description", TagInfo.testBuilder().build(), 10000, 100, 4000, PlanStatus.ACTIVE, RcmndStatus.NONE, Collections.emptyList(), Collections.emptyList(), 4400);
-
-        given(spyPlanRepository.findAllByOrderAndUserId(any())).willReturn((List<OrderedPlan>) List.of(givenPlan));
-
-        OrderListResponse result = orderService.getOrderedPlanList(1L);
-
-        Assertions.assertThat(result.getContents().get(0).getOrderPrice()).isEqualTo(givenPlan.getOrderPrice());
-        Assertions.assertThat(result.getContents().get(0).getPlanId()).isEqualTo(givenPlan.getId());
-        Assertions.assertThat(result.getContents().get(0).getThumbnailUrl()).isEqualTo(givenPlan.getThumbnailUrl());
-        Assertions.assertThat(result.getContents().get(0).getTitle()).isEqualTo(givenPlan.getTitle());
     }
 }

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/OrderedPlan.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/OrderedPlan.java
@@ -1,23 +1,18 @@
 package com.deploy.bemyplan.domain.plan;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
 
-import java.util.List;
+public interface OrderedPlan {
 
+    Long getId();
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class OrderedPlan extends Plan {
-    private int orderPrice;
+    String getTitle();
 
-    private OrderedPlan(final Long userId, final RegionCategory regionCategory, final Region region, final String thumbnailUrl, final String title, final String description, final TagInfo tagInfo, final int orderCnt, final int viewCnt, final int price, final PlanStatus status, final RcmndStatus rcmndStatus, final List<String> hashtags, final List<String> recommendTargets, final int orderPrice) {
-        super(userId, regionCategory, region, thumbnailUrl, title, description, tagInfo, orderCnt, viewCnt, price, status, rcmndStatus, hashtags, recommendTargets);
-        this.orderPrice = orderPrice;
-    }
+    String getThumbnailUrl();
 
-    public static OrderedPlan newInstance(final Long userId, final RegionCategory regionCategory, final Region region, final String thumbnailUrl, final String title, final String description, final TagInfo tagInfo, final int orderCnt, final int viewCnt, final int price, final PlanStatus status, final RcmndStatus rcmndStatus, final List<String> hashtags, final List<String> recommendTargets, final int orderPrice) {
-        return new OrderedPlan(userId, regionCategory, region, thumbnailUrl, title, description, tagInfo, orderCnt, viewCnt, price, status, rcmndStatus, hashtags, recommendTargets, orderPrice);
-    }
+    Integer getOrderPrice();
+
+    LocalDateTime getCreatedAt();
+
+    LocalDateTime getUpdatedAt();
 }

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/OrderedPlan.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/OrderedPlan.java
@@ -1,0 +1,23 @@
+package com.deploy.bemyplan.domain.plan;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderedPlan extends Plan {
+    private int orderPrice;
+
+    private OrderedPlan(final Long userId, final RegionCategory regionCategory, final Region region, final String thumbnailUrl, final String title, final String description, final TagInfo tagInfo, final int orderCnt, final int viewCnt, final int price, final PlanStatus status, final RcmndStatus rcmndStatus, final List<String> hashtags, final List<String> recommendTargets, final int orderPrice) {
+        super(userId, regionCategory, region, thumbnailUrl, title, description, tagInfo, orderCnt, viewCnt, price, status, rcmndStatus, hashtags, recommendTargets);
+        this.orderPrice = orderPrice;
+    }
+
+    public static OrderedPlan newInstance(final Long userId, final RegionCategory regionCategory, final Region region, final String thumbnailUrl, final String title, final String description, final TagInfo tagInfo, final int orderCnt, final int viewCnt, final int price, final PlanStatus status, final RcmndStatus rcmndStatus, final List<String> hashtags, final List<String> recommendTargets, final int orderPrice) {
+        return new OrderedPlan(userId, regionCategory, region, thumbnailUrl, title, description, tagInfo, orderCnt, viewCnt, price, status, rcmndStatus, hashtags, recommendTargets, orderPrice);
+    }
+}

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Plan.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Plan.java
@@ -83,7 +83,7 @@ public class Plan extends AuditingTimeEntity {
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<DailySchedule> schedules = new ArrayList<>();
 
-    protected Plan(final Long userId, final RegionCategory regionCategory, final Region region, final String thumbnailUrl, final String title, final String description, final TagInfo tagInfo, final int orderCnt, final int viewCnt, final int price, final PlanStatus status, final RcmndStatus rcmndStatus, final List<String> hashtags, final List<String> recommendTargets) {
+    private Plan(final Long userId, final RegionCategory regionCategory, final Region region, final String thumbnailUrl, final String title, final String description, final TagInfo tagInfo, final int orderCnt, final int viewCnt, final int price, final PlanStatus status, final RcmndStatus rcmndStatus, final List<String> hashtags, final List<String> recommendTargets) {
         this(userId, regionCategory, region, thumbnailUrl, title, description, tagInfo, orderCnt, viewCnt, price, status, rcmndStatus,
                 hashtags, recommendTargets, Collections.emptyList());
     }

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Plan.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/Plan.java
@@ -25,7 +25,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(callSuper=false)
+@EqualsAndHashCode(callSuper = false)
 public class Plan extends AuditingTimeEntity {
 
     @Id
@@ -83,7 +83,7 @@ public class Plan extends AuditingTimeEntity {
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<DailySchedule> schedules = new ArrayList<>();
 
-    private Plan(final Long userId, final RegionCategory regionCategory, final Region region, final String thumbnailUrl, final String title, final String description, final TagInfo tagInfo, final int orderCnt, final int viewCnt, final int price, final PlanStatus status, final RcmndStatus rcmndStatus, final List<String> hashtags, final List<String> recommendTargets) {
+    protected Plan(final Long userId, final RegionCategory regionCategory, final Region region, final String thumbnailUrl, final String title, final String description, final TagInfo tagInfo, final int orderCnt, final int viewCnt, final int price, final PlanStatus status, final RcmndStatus rcmndStatus, final List<String> hashtags, final List<String> recommendTargets) {
         this(userId, regionCategory, region, thumbnailUrl, title, description, tagInfo, orderCnt, viewCnt, price, status, rcmndStatus,
                 hashtags, recommendTargets, Collections.emptyList());
     }

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/PlanRepository.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/PlanRepository.java
@@ -17,4 +17,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long>, PlanRepositor
 
     @Query("select p from Plan p where p.status = 'ACTIVE' and p.rcmndStatus = 'RECOMMENDED' order by p.id desc")
     List<Plan> findPickList();
+
+    @Query("select p, o.orderPrice from Plan p inner join Order o on p.id = o.planId where o.userId = :userId and o.status = 'COMPLETED'")
+    List<OrderedPlan> findAllByOrderAndUserId(@Param("userId") Long userId);
 }

--- a/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/PlanRepository.java
+++ b/module-domain-bemyplan/src/main/java/com/deploy/bemyplan/domain/plan/PlanRepository.java
@@ -18,6 +18,12 @@ public interface PlanRepository extends JpaRepository<Plan, Long>, PlanRepositor
     @Query("select p from Plan p where p.status = 'ACTIVE' and p.rcmndStatus = 'RECOMMENDED' order by p.id desc")
     List<Plan> findPickList();
 
-    @Query("select p, o.orderPrice from Plan p inner join Order o on p.id = o.planId where o.userId = :userId and o.status = 'COMPLETED'")
+    @Query(value = "select p.id, p.title, p. thumbnail_url as thumbnailUrl, " +
+            "p.created_at as createdAt, p.updated_at as updatedAt, " +
+            "o.order_price as orderPrice " +
+            "from plan p " +
+            "inner join orders o on p.id = o.plan_id " +
+            "where o.user_id = :userId and o.status = 'COMPLETED'",
+            nativeQuery = true)
     List<OrderedPlan> findAllByOrderAndUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
#156 
1. 
기존 여행 일정 구매 api 에서 
전 : 여행 일정의 금액 -> 주문 금액으로 설정
후 : 클라이언트에서 보낸 결제 금액 -> 주문 금액으로 설정
으로 변경하였습니다.

2. 마이페이지 - 구매 내역 조회 api를 새로 생성하였습니다.